### PR TITLE
Use apex-domain for hacklabfi -link.

### DIFF
--- a/src/websites/hackab.fi.md
+++ b/src/websites/hackab.fi.md
@@ -1,6 +1,6 @@
 # hacklab.fi
 
-The main site for Hacklabs <https://www.hacklab.fi>
+The main site for Hacklabs <https://hacklab.fi>
 
 Jekyll site in Github Pages.
 


### PR DESCRIPTION
This has been our convention for long :)

Signed-off-by: Sami Olmari <sami@olmari.fi>